### PR TITLE
add new sub_state return value to service_facts module

### DIFF
--- a/lib/ansible/modules/service_facts.py
+++ b/lib/ansible/modules/service_facts.py
@@ -58,6 +58,13 @@ EXAMPLES = r"""
     name: ntpd.service
   when: ansible_facts['services']['ntpd.service']['status'] | default('not-found') != 'not-found'
 
+- name: show names of existing systemd services in dead sub_state
+  debug:
+    msg: "{{ existing_systemd_services | selectattr('sub_state', 'equalto', 'dead') | map(attribute='name')}}"
+  vars:
+   known_systemd_services: "{{ ansible_facts['services'].values() | selectattr('source', 'equalto', 'systemd') }}"
+   existing_systemd_services: "{{ known_systemd_services | rejectattr('status', 'equalto', 'not-found') }}"
+
 """
 
 RETURN = r"""
@@ -87,6 +94,14 @@ ansible_facts:
           returned: always
           type: str
           sample: running
+        sub_state:
+          description:
+          - SUB State of the service.
+          - 'This commonly includes the low-level unit activation state, like: V(running), V(exited), V(dead), V(failed), V(inactive) or V(unknown).'
+          - Depending on the used init system additional states might be returned.
+          returned: if source is V(systemd)
+          type: str
+          sample: dead
         status:
           description:
           - State of the service.
@@ -289,10 +304,11 @@ class SystemctlScanService(BaseService):
                     status_val = fields[2]
 
                 service_name = fields[0]
-                if fields[3] == "running":
+                sub_state_val = fields[3]
+                if sub_state_val == "running":
                     state_val = "running"
 
-                services[service_name] = {"name": service_name, "state": state_val, "status": status_val, "source": "systemd"}
+                services[service_name] = {"name": service_name, "state": state_val, "sub_state": sub_state_val, "status": status_val, "source": "systemd"}
 
     def _list_from_unit_files(self, systemctl_path, services):
 
@@ -312,7 +328,7 @@ class SystemctlScanService(BaseService):
                     state = 'unknown'
                     if not rc and stdout != '':
                         state = stdout.replace('ActiveState=', '').rstrip()
-                    services[service_name] = {"name": service_name, "state": state, "status": status_val, "source": "systemd"}
+                    services[service_name] = {"name": service_name, "state": state, "sub_state": state, "status": status_val, "source": "systemd"}
                 elif services[service_name]["status"] not in self.BAD_STATES:
                     services[service_name]["status"] = status_val
 


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

The **`ansible.builtin.service_facts`** module does not accurately report the state of services when the source is systemd.

On hosts using **`systemd`**, the state **`exited`** or **`dead`** indicates that the service is inactive.
However, this does not confirm that the service is properly in the stopped state.

According to the code in the **`SystemctlScanService`** class [here](https://github.com/ansible/ansible/blob/e6adddcaf8d4cf46185a90be89a574ba01cc6b84/lib/ansible/modules/service_facts.py#L260C1-L295C127) :

the service state on hosts is determined by the **`SUB`** parameter from the following command.

```
$ systemctl list-units --no-pager --type service --all --plain
```
Unfortunately, the SUB parameter, which is referenced as **`fields[3]`**, is later overridden by the **`state_val`** variable, which is set to **`stopped`** by default at the beginning.

As a result, this leads to the module always returning only two possible outcomes: **`stopped`** or **`running`**, rather than accurately reporting the true state of the services.

The best solution would be to add a new value, **`sub_state`**, that reflects the exact state from **`systemctl`**, but only when the source is systemd.

I have modified the **`service_facts.py`** file by adding the return of a new value, **`sub_state`**.

* The **`state`** value remains unchanged.
* The new value, **`sub_state`**, has been added to reflect the **`SUB`** state of **`systemctl`**.

To avoid errors, the **`sub_state`** value has been added to both **`_list_from_units`** and **`_list_from_unit_files`**.

In **`_list_from_unit_files`**, the **`sub_state`** value will be identical to **`state`**.

I have modified the documentation with sub_state description and example

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Feature Pull Request
